### PR TITLE
fix improper brace placement in several classes

### DIFF
--- a/src/main/java/kipster/nt/biomes/cool/BiomeAutumnTaiga.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeAutumnTaiga.java
@@ -126,8 +126,8 @@ public class BiomeAutumnTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
 	@Override

--- a/src/main/java/kipster/nt/biomes/cool/BiomeBlueTaiga.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeBlueTaiga.java
@@ -109,8 +109,8 @@ public class BiomeBlueTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
    @Override

--- a/src/main/java/kipster/nt/biomes/cool/BiomeCliffs.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeCliffs.java
@@ -74,6 +74,7 @@ public class BiomeCliffs extends Biome
 	                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	                COBBLESTONE_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 	            }
+	       }
 	            if (!MiscConfig.disableBouldersInCliffs && net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.ROCK)) {
 		            int genChance1 = rand.nextInt(3);
 		            if (genChance1 == 0) {
@@ -83,7 +84,6 @@ public class BiomeCliffs extends Biome
 		                COBBLESTONE_LINE.generate(worldIn, rand, blockpos);
 		            }
 	            }
-	       }
 	super.decorate(worldIn, rand, pos);
 		
 	}

--- a/src/main/java/kipster/nt/biomes/cool/BiomeMapleForest.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeMapleForest.java
@@ -97,8 +97,8 @@ public class BiomeMapleForest extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    @Override
    public void genTerrainBlocks(World worldIn, Random rand, ChunkPrimer chunkPrimerIn, int x, int z, double noiseVal) {

--- a/src/main/java/kipster/nt/biomes/cool/BiomeMegaAutumnTaiga.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeMegaAutumnTaiga.java
@@ -112,8 +112,8 @@ public class BiomeMegaAutumnTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
 	@Override

--- a/src/main/java/kipster/nt/biomes/cool/BiomeMegaBlueTaiga.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeMegaBlueTaiga.java
@@ -114,8 +114,8 @@ public class BiomeMegaBlueTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
    @Override

--- a/src/main/java/kipster/nt/biomes/cool/BiomeMegaMapleForest.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeMegaMapleForest.java
@@ -118,8 +118,8 @@ public class BiomeMegaMapleForest extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
    @Override

--- a/src/main/java/kipster/nt/biomes/cool/BiomeStoneFields.java
+++ b/src/main/java/kipster/nt/biomes/cool/BiomeStoneFields.java
@@ -88,8 +88,8 @@ public class BiomeStoneFields extends Biome
             int k = rand.nextInt(16) + 8;
             this.stoneSpike.generate(worldIn, rand, worldIn.getHeight(pos.add(j, 0, k)));
         }
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 	}
 	
 	 public static class DiamondGenerator extends WorldGenerator

--- a/src/main/java/kipster/nt/biomes/desert/BiomeClayland.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeClayland.java
@@ -136,6 +136,7 @@ public class BiomeClayland extends Biome
 		                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		                CLAY_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 		            }
+	          }
 		            if (!MiscConfig.disableBouldersInClayland && net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.ROCK)) {
 			            int genChance1 = rand.nextInt(3);
 			            if (genChance1 == 0) {
@@ -146,7 +147,6 @@ public class BiomeClayland extends Biome
 			            }
 		            }
 	            }
-	          }
 	        
 	        @Override
 	  			public int getModdedBiomeGrassColor(int original) {

--- a/src/main/java/kipster/nt/biomes/desert/BiomeLushDesert.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeLushDesert.java
@@ -157,6 +157,7 @@ public class BiomeLushDesert extends Biome
             BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
             LAKE.generate(worldIn, rand, blockpos);
           }
+	  }
           net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Pre(worldIn, rand, pos));
           WorldGenerator gold = new GoldGenerator();
           
@@ -166,7 +167,6 @@ public class BiomeLushDesert extends Biome
 	  if (rand.nextInt(64) == 0)
 	  {
 	      (new WorldGenFossils()).generate(worldIn, rand, pos);
-	  }
 	  }
 	  net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 	

--- a/src/main/java/kipster/nt/biomes/desert/BiomeRockland.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeRockland.java
@@ -136,7 +136,8 @@ public class BiomeRockland extends Biome
 		                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		                STONE_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 		            }
-		            if (!MiscConfig.disableBouldersInRockland && net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.ROCK)) {
+	            }
+                if (!MiscConfig.disableBouldersInRockland && net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.ROCK)) {
 			            int genChance1 = rand.nextInt(3);
 			            if (genChance1 == 0) {
 			                int k6 = rand.nextInt(16) + 8;
@@ -145,7 +146,6 @@ public class BiomeRockland extends Biome
 			                STONE.generate(worldIn, rand, blockpos);
 			            }
 		            }
-	            }
 	          }
 	        
 	        @Override

--- a/src/main/java/kipster/nt/biomes/desert/BiomeSandyMountains.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeSandyMountains.java
@@ -110,6 +110,8 @@ public class BiomeSandyMountains extends Biome
   	             BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
   	             LAVA_LAKE_FEATURE.generate(worldIn, rand, blockpos);
   	           }
+              }
+
 	            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, new net.minecraft.util.math.ChunkPos(pos), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
 	            if (rand.nextInt(1000) == 0)
 	            {
@@ -124,7 +126,6 @@ public class BiomeSandyMountains extends Biome
 	            {
 	                (new WorldGenFossils()).generate(worldIn, rand, pos);
 	            }
-	 	      }
 	            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 	        }
 

--- a/src/main/java/kipster/nt/biomes/desert/BiomeSandyScrubland.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeSandyScrubland.java
@@ -115,6 +115,7 @@ public class BiomeSandyScrubland extends Biome
 	    	             BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	    	             LAVA_LAKE_FEATURE.generate(worldIn, rand, blockpos);
 	    	           }
+				 }
 				
 				 if (!MiscConfig.disableBouldersInSandyScrubland && net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.ROCK)) {
 		            int genChance = rand.nextInt(3);
@@ -124,6 +125,7 @@ public class BiomeSandyScrubland extends Biome
 		                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		                SAND_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 		            }
+                }
 				
 	            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, new net.minecraft.util.math.ChunkPos(pos), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
 	            if (rand.nextInt(1000) == 0)
@@ -140,8 +142,6 @@ public class BiomeSandyScrubland extends Biome
 	                (new WorldGenFossils()).generate(worldIn, rand, pos);
 	            }
 	            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
-				 }
-				   }
 	        }
 				@Override
 			   	public int getModdedBiomeGrassColor(int original) {

--- a/src/main/java/kipster/nt/biomes/desert/BiomeScrubland.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeScrubland.java
@@ -99,6 +99,7 @@ public class BiomeScrubland extends Biome
   	             BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
   	             LAVA_LAKE_FEATURE.generate(worldIn, rand, blockpos);
   	           }
+	     }
 	         
 	      
 	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Pre(worldIn, rand, pos));
@@ -107,7 +108,6 @@ public class BiomeScrubland extends Biome
 	 	    	   gold.generate(worldIn, rand, pos);
 
 	         super.decorate(worldIn, rand, pos);
-	     }
 	     }
 	     
 	     public static class GoldGenerator extends WorldGenerator

--- a/src/main/java/kipster/nt/biomes/desert/BiomeTropicalDesert.java
+++ b/src/main/java/kipster/nt/biomes/desert/BiomeTropicalDesert.java
@@ -165,6 +165,7 @@ public class BiomeTropicalDesert extends Biome
             BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
             LAKE.generate(worldIn, rand, blockpos);
           }
+	  }
           net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Pre(worldIn, rand, pos));
           WorldGenerator gold = new GoldGenerator();
           
@@ -174,7 +175,6 @@ public class BiomeTropicalDesert extends Biome
 	  if (rand.nextInt(64) == 0)
 	  {
 	      (new WorldGenFossils()).generate(worldIn, rand, pos);
-	  }
 	  }
 	  net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 	

--- a/src/main/java/kipster/nt/biomes/icy/BiomeColdBlueTaiga.java
+++ b/src/main/java/kipster/nt/biomes/icy/BiomeColdBlueTaiga.java
@@ -108,8 +108,8 @@ public class BiomeColdBlueTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
    

--- a/src/main/java/kipster/nt/biomes/icy/BiomeColdMegaBlueTaiga.java
+++ b/src/main/java/kipster/nt/biomes/icy/BiomeColdMegaBlueTaiga.java
@@ -114,8 +114,8 @@ public class BiomeColdMegaBlueTaiga extends Biome
            }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
-       super.decorate(worldIn, rand, pos);
        }
+       super.decorate(worldIn, rand, pos);
    }
    
    @Override

--- a/src/main/java/kipster/nt/biomes/icy/BiomeGlacier.java
+++ b/src/main/java/kipster/nt/biomes/icy/BiomeGlacier.java
@@ -112,8 +112,8 @@ public class BiomeGlacier extends Biome
 	            
 	            }
            
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 	}
 	 public static class LapisGenerator extends WorldGenerator
 	    {

--- a/src/main/java/kipster/nt/biomes/warm/BiomeAegeanArchipelago.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeAegeanArchipelago.java
@@ -78,17 +78,17 @@ public class BiomeAegeanArchipelago extends Biome
 	                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	                STONE_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 	            }
-	        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, new net.minecraft.util.math.ChunkPos(pos), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
-	        if (rand.nextInt(64) == 0)  	
-	        {	            
+	        }
+	        //if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, new net.minecraft.util.math.ChunkPos(pos), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
+	        //if (rand.nextInt(64) == 0)  	
+	        //{	            
+	        //}
 	        net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Pre(worldIn, rand, pos));
 	        WorldGenerator emeralds = new EmeraldGenerator();
 	        if (net.minecraftforge.event.terraingen.TerrainGen.generateOre(worldIn, rand, emeralds, pos, net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.EMERALD))
 	            emeralds.generate(worldIn, rand, pos);
 	      
 	        net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
-	        }
-	        }
 	    }
 	        @Override
 	    	public int getModdedBiomeGrassColor(int original) {

--- a/src/main/java/kipster/nt/biomes/warm/BiomeAliumMeadow.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeAliumMeadow.java
@@ -88,8 +88,8 @@ public class BiomeAliumMeadow extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 			 }
 	
 	 @Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomeAutumnForest.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeAutumnForest.java
@@ -120,10 +120,10 @@ public class BiomeAutumnForest extends Biome
              BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
              LAKE.generate(worldIn, rand, blockpos);
            }
+       }
            net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
        super.decorate(worldIn, rand, pos);
-       }
    }
    
 	@Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomeBirchHills.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeBirchHills.java
@@ -86,8 +86,8 @@ public class BiomeBirchHills extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 			 }
 	
 

--- a/src/main/java/kipster/nt/biomes/warm/BiomeFungalJungle.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeFungalJungle.java
@@ -154,6 +154,7 @@ public WorldGenerator getRandomWorldGenForGrass(Random rand)
 	           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	           LAKE.generate(worldIn, rand, blockpos);
 	         }
+         }
 	         int i = rand.nextInt(16) + 8;
 	         int j = rand.nextInt(16) + 8;
 	         int height = worldIn.getHeight(pos.add(i, 0, j)).getY() * 2; // could == 0, which crashes nextInt
@@ -188,11 +189,10 @@ public WorldGenerator getRandomWorldGenForGrass(Random rand)
 	 			BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	 			MUSHROOM_PATCHES.generate(worldIn, rand, blockpos);
 	        
-	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 	        }
+	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
 	    super.decorate(worldIn, rand, pos);
-	        }
 	}
 	
 	   @Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomeGrassHills.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeGrassHills.java
@@ -74,6 +74,7 @@ public class BiomeGrassHills extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
+            }
 	        
 	        
 			 if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
@@ -86,7 +87,6 @@ public class BiomeGrassHills extends Biome
 			
 			 }
 	    super.decorate(worldIn, rand, pos);
-		}
 	}
 
 	 public static class EmeraldGenerator extends WorldGenerator

--- a/src/main/java/kipster/nt/biomes/warm/BiomeGreenMixedForest.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeGreenMixedForest.java
@@ -84,8 +84,8 @@ public class BiomeGreenMixedForest extends Biome
 	              BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	              LAKE.generate(worldIn, rand, blockpos);
 	         }
-	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 	        }
+	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
 
 	    super.decorate(worldIn, rand, pos);
 	        }

--- a/src/main/java/kipster/nt/biomes/warm/BiomeHotSpring.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeHotSpring.java
@@ -92,18 +92,15 @@ public class BiomeHotSpring extends Biome
 	           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 	           LAKE.generate(worldIn, rand, blockpos);
 	         }
+         }
 	         int grasspatchChance = rand.nextInt(4);
 				if (grasspatchChance == 0) {
 					int k6 = rand.nextInt(16) + 8;
 					int l = rand.nextInt(16) + 8;
 					BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 					GRASS_PATCHES.generate(worldIn, rand, blockpos);
-				
-	   
 	        }
-
 	    super.decorate(worldIn, rand, pos);
-	        }
 	}
 	
 	 public static class EmeraldGenerator extends WorldGenerator

--- a/src/main/java/kipster/nt/biomes/warm/BiomeMeadow.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeMeadow.java
@@ -127,8 +127,8 @@ public class BiomeMeadow extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 			 }
 	
 	@Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomeMonsoonForest.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeMonsoonForest.java
@@ -172,6 +172,7 @@ public WorldGenerator getRandomWorldGenForGrass(Random rand)
 	                BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	                STONE_BOULDER_FEATURE.generate(worldIn, rand, blockpos);
 	            }
+            }
 	        
 		 if (net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, DecorateBiomeEvent.Decorate.EventType.LAKE_WATER)) {
 	         int boulderChance = rand.nextInt(12);
@@ -181,6 +182,7 @@ public WorldGenerator getRandomWorldGenForGrass(Random rand)
 	           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 	           LAKE.generate(worldIn, rand, blockpos);
 	         }
+         }
 	         int i = rand.nextInt(16) + 8;
 	         int j = rand.nextInt(16) + 8;
 	         int height = worldIn.getHeight(pos.add(i, 0, j)).getY() * 2; // could == 0, which crashes nextInt
@@ -208,9 +210,7 @@ public WorldGenerator getRandomWorldGenForGrass(Random rand)
 	         this.addDoublePlants(worldIn, rand, pos, i1);
 	         
 	         net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
-	        }
 		 }
-	        }
 	    super.decorate(worldIn, rand, pos);
 	        
 	}

--- a/src/main/java/kipster/nt/biomes/warm/BiomeMoorland.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeMoorland.java
@@ -68,6 +68,7 @@ public class BiomeMoorland extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
+            }
 	        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, new net.minecraft.util.math.ChunkPos(pos), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
 	        if (rand.nextInt(64) == 0)
 	        {
@@ -79,7 +80,6 @@ public class BiomeMoorland extends Biome
 	            emeralds.generate(worldIn, rand, pos);
 	      
 	        net.minecraftforge.common.MinecraftForge.ORE_GEN_BUS.post(new net.minecraftforge.event.terraingen.OreGenEvent.Post(worldIn, rand, pos));
-	    }
 	    }
 
 	    @Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomePoppyMeadow.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomePoppyMeadow.java
@@ -97,8 +97,8 @@ public class BiomePoppyMeadow extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, l));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
-	    super.decorate(worldIn, rand, pos);
 		}
+	    super.decorate(worldIn, rand, pos);
 			 }
 	
 	 @Override

--- a/src/main/java/kipster/nt/biomes/warm/BiomeSprings.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeSprings.java
@@ -91,6 +91,7 @@ public class BiomeSprings extends Biome
 	           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 	           LAKE.generate(worldIn, rand, blockpos);
 	         }
+	     }
 	         int grasspatchChance = rand.nextInt(4);
 				if (grasspatchChance == 0) {
 					int k6 = rand.nextInt(16) + 8;
@@ -102,7 +103,6 @@ public class BiomeSprings extends Biome
 	        }
 
 	    super.decorate(worldIn, rand, pos);
-	        }
 	}
 	
 	 public static class EmeraldGenerator extends WorldGenerator

--- a/src/main/java/kipster/nt/biomes/warm/BiomeWhiteOrchard.java
+++ b/src/main/java/kipster/nt/biomes/warm/BiomeWhiteOrchard.java
@@ -92,6 +92,7 @@ public class BiomeWhiteOrchard extends Biome
 		           BlockPos blockpos = worldIn.getHeight(pos.add(k6, 0, 1));
 		           LAKE.generate(worldIn, rand, blockpos);
 		         }
+            }
 	        
 			 if(net.minecraftforge.event.terraingen.TerrainGen.decorate(worldIn, rand, pos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
 			 for (int i = 0; i < 7; ++i)
@@ -103,7 +104,6 @@ public class BiomeWhiteOrchard extends Biome
 			
 			 }
 	    super.decorate(worldIn, rand, pos);
-		}
 	}
 	 @Override
 	    public void addDefaultFlowers()


### PR DESCRIPTION
This PR fixes the improper placement of braces in the `#decorate` override of several biome classes.
The improper placement prevents several decoration processes, or the call to `super#decorate`, from executing properly if certain events are `DENY`ed by event listeners.